### PR TITLE
Persist WiFi credentials between reboots

### DIFF
--- a/SpotifyDiyThing/SpotifyDiyThing.ino
+++ b/SpotifyDiyThing/SpotifyDiyThing.ino
@@ -30,6 +30,8 @@
 // This causes issues in certain circumstances e.g. Play an album and let it auto play to related songs
 bool writeContextToNfc = true;
 
+const unsigned long WIFI_CONNECT_TIMEOUT_MS = 20000;
+
 // ----------------------------
 // Library Defines - Need to be defined before library import
 // ----------------------------
@@ -119,6 +121,40 @@ void drawWifiManagerMessage(WiFiManager *myWiFiManager)
   spotifyDisplay->drawWifiManagerMessage(myWiFiManager);
 }
 
+bool connectToStoredWifi()
+{
+  if (wifiSsid[0] == '\0')
+  {
+    Serial.println(F("No WiFi credentials found in config"));
+    return false;
+  }
+
+  Serial.print(F("Connecting to stored WiFi SSID: "));
+  Serial.println(wifiSsid);
+
+  WiFi.mode(WIFI_STA);
+  WiFi.persistent(true);
+  WiFi.begin(wifiSsid, wifiPassword);
+
+  unsigned long startAttemptTime = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - startAttemptTime < WIFI_CONNECT_TIMEOUT_MS)
+  {
+    delay(500);
+    Serial.print('.');
+  }
+  Serial.println();
+
+  if (WiFi.status() == WL_CONNECTED)
+  {
+    WiFi.setAutoReconnect(true);
+    Serial.println(F("Connected to WiFi using stored credentials"));
+    return true;
+  }
+
+  Serial.println(F("Failed to connect with stored WiFi credentials"));
+  return false;
+}
+
 void setup()
 {
   Serial.begin(115200);
@@ -160,13 +196,34 @@ void setup()
   Serial.println("\r\nInitialisation done.");
 
   refreshToken[0] = '\0';
-  if (!fetchConfigFile(refreshToken, clientId, clientSecret))
+  wifiSsid[0] = '\0';
+  wifiPassword[0] = '\0';
+  bool haveStoredConfig = fetchConfigFile(refreshToken, clientId, clientSecret, wifiSsid, wifiPassword);
+  if (!haveStoredConfig)
   {
     // Failed to fetch config file, need to launch Wifi Manager
     forceConfig = true;
   }
 
-  setupWiFiManager(forceConfig, refreshToken, &saveConfigFile, &drawWifiManagerMessage);
+  bool wifiConnected = false;
+  if (!forceConfig)
+  {
+    wifiConnected = connectToStoredWifi();
+  }
+
+  if (!wifiConnected)
+  {
+    setupWiFiManager(forceConfig, refreshToken, &saveConfigFile, &drawWifiManagerMessage);
+    wifiConnected = WiFi.isConnected();
+  }
+
+  if (!wifiConnected)
+  {
+    Serial.println(F("Failed to connect to WiFi"));
+  }
+
+  WiFi.setAutoReconnect(true);
+  WiFi.persistent(true);
 
   // If we are here we should be connected to the Wifi
   Serial.print("IP address: ");
@@ -198,7 +255,7 @@ void setup()
     {
       Serial.print("Refresh Token: ");
       Serial.println(refreshToken);
-      saveConfigFile(refreshToken, clientId, clientSecret);
+      saveConfigFile(refreshToken, clientId, clientSecret, wifiSsid, wifiPassword);
     }
   }
 

--- a/SpotifyDiyThing/WifiManagerHandler.h
+++ b/SpotifyDiyThing/WifiManagerHandler.h
@@ -1,4 +1,5 @@
-
+#include <cstdio>
+#include <cstring>
 // Number of seconds after reset during which a
 // subseqent reset will be considered a double reset.
 #define DRD_TIMEOUT 10
@@ -9,6 +10,17 @@
 #define WM_CLIENT_ID_LABEL "clientID"
 #define WM_CLIENT_SECRET_LABEL "clientSecret"
 #define WM_REFRESH_TOKEN_LABEL "refreshToken"
+
+#ifndef WIFI_SSID_FIELD_LENGTH
+#define WIFI_SSID_FIELD_LENGTH 33
+#endif
+
+#ifndef WIFI_PASSWORD_FIELD_LENGTH
+#define WIFI_PASSWORD_FIELD_LENGTH 65
+#endif
+
+char wifiSsid[WIFI_SSID_FIELD_LENGTH];
+char wifiPassword[WIFI_PASSWORD_FIELD_LENGTH];
 
 DoubleResetDetector* drd;
 
@@ -24,7 +36,7 @@ void saveConfigCallback () {
   shouldSaveConfig = true;
 }
 
-void setupWiFiManager(bool forceConfig, char *refreshToken, void (*saveConfig)(char *, char *, char *), void (*configModeCallback)(WiFiManager *myWiFiManager)){
+void setupWiFiManager(bool forceConfig, char *refreshToken, void (*saveConfig)(char *, char *, char *, const char *, const char *), void (*configModeCallback)(WiFiManager *myWiFiManager)){
   WiFiManager wm;
   //set config save notify callback
   wm.setSaveConfigCallback(saveConfigCallback);
@@ -67,10 +79,30 @@ void setupWiFiManager(bool forceConfig, char *refreshToken, void (*saveConfig)(c
     strncpy(clientSecret, clientSecretParam.getValue(), 40);
     strncpy(refreshToken, clientRefreshToken.getValue(), 399);
 
-    saveConfig(refreshToken, clientId, clientSecret);
+    String currentSsid = wm.getWiFiSSID(true);
+    String currentPass = wm.getWiFiPass(true);
+
+    snprintf(wifiSsid, WIFI_SSID_FIELD_LENGTH, "%s", currentSsid.c_str());
+    snprintf(wifiPassword, WIFI_PASSWORD_FIELD_LENGTH, "%s", currentPass.c_str());
+
+    saveConfig(refreshToken, clientId, clientSecret, wifiSsid, wifiPassword);
     drd->stop();
     ESP.restart();
     delay(5000);
+  }
+  else
+  {
+    if (wifiSsid[0] == '\0')
+    {
+      String currentSsid = wm.getWiFiSSID(true);
+      snprintf(wifiSsid, WIFI_SSID_FIELD_LENGTH, "%s", currentSsid.c_str());
+    }
+
+    if (wifiPassword[0] == '\0')
+    {
+      String currentPass = wm.getWiFiPass(true);
+      snprintf(wifiPassword, WIFI_PASSWORD_FIELD_LENGTH, "%s", currentPass.c_str());
+    }
   }
   
 }

--- a/SpotifyDiyThing/configFile.h
+++ b/SpotifyDiyThing/configFile.h
@@ -1,10 +1,30 @@
+#include <cstring>
+
 #define SPOTIFY_CONFIG_JSON "/spotify_diy_config.json"
 
 #define REFRESH_TOKEN_LABEL "refreshToken"
 #define CLIENT_ID_LABEL "clientId"
 #define CLIENT_SECRET_LABEL "clientSecret"
+#define WIFI_SSID_LABEL "wifiSsid"
+#define WIFI_PASSWORD_LABEL "wifiPassword"
 
-bool fetchConfigFile(char *refreshToken, char *clientId, char *clientSecret) {
+#ifndef WIFI_SSID_FIELD_LENGTH
+#define WIFI_SSID_FIELD_LENGTH 33
+#endif
+
+#ifndef WIFI_PASSWORD_FIELD_LENGTH
+#define WIFI_PASSWORD_FIELD_LENGTH 65
+#endif
+
+bool fetchConfigFile(char *refreshToken, char *clientId, char *clientSecret, char *wifiSsid, char *wifiPassword) {
+  if (wifiSsid != nullptr)
+  {
+    wifiSsid[0] = '\0';
+  }
+  if (wifiPassword != nullptr)
+  {
+    wifiPassword[0] = '\0';
+  }
   if (SPIFFS.exists(SPOTIFY_CONFIG_JSON)) {
     //file exists, reading and loading
     Serial.println("reading config file");
@@ -29,6 +49,28 @@ bool fetchConfigFile(char *refreshToken, char *clientId, char *clientSecret) {
           return false;
         }
 
+        if (wifiSsid != nullptr)
+        {
+          if (json.containsKey(WIFI_SSID_LABEL)) {
+            strncpy(wifiSsid, json[WIFI_SSID_LABEL], WIFI_SSID_FIELD_LENGTH - 1);
+            wifiSsid[WIFI_SSID_FIELD_LENGTH - 1] = '\0';
+          }
+          else {
+            wifiSsid[0] = '\0';
+          }
+        }
+
+        if (wifiPassword != nullptr)
+        {
+          if (json.containsKey(WIFI_PASSWORD_LABEL)) {
+            strncpy(wifiPassword, json[WIFI_PASSWORD_LABEL], WIFI_PASSWORD_FIELD_LENGTH - 1);
+            wifiPassword[WIFI_PASSWORD_FIELD_LENGTH - 1] = '\0';
+          }
+          else {
+            wifiPassword[0] = '\0';
+          }
+        }
+
         return true;
 
       } else {
@@ -45,12 +87,14 @@ bool fetchConfigFile(char *refreshToken, char *clientId, char *clientSecret) {
   }
 }
 
-void saveConfigFile(char *refreshToken, char *clientId, char *clientSecret) {
+void saveConfigFile(char *refreshToken, char *clientId, char *clientSecret, const char *wifiSsid, const char *wifiPassword) {
   Serial.println(F("Saving config"));
   StaticJsonDocument<512> json;
   json[REFRESH_TOKEN_LABEL] = refreshToken;
   json[CLIENT_ID_LABEL] = clientId;
   json[CLIENT_SECRET_LABEL] = clientSecret;
+  json[WIFI_SSID_LABEL] = wifiSsid;
+  json[WIFI_PASSWORD_LABEL] = wifiPassword;
 
   File configFile = SPIFFS.open(SPOTIFY_CONFIG_JSON, "w");
   if (!configFile) {


### PR DESCRIPTION
## Summary
- persist WiFi SSID/password alongside existing Spotify credentials in the config file
- try connecting with stored credentials before launching WiFiManager and ensure the arrays stay in sync
- update the WiFiManager save path to record WiFi details and use the new config signature throughout

## Testing
- pio run *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4109df7ac8330888a837dc5fc39f4