### PR TITLE
Switch configuration storage to YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,20 @@ You should be automatically redirected to the config page.
 
 Note: If you ever need to get back into this config section, click reset button (the button closest to the side) twice.
 
+#### Alternative: Configure via microSD card
+
+If you would prefer to skip the captive portal you can provide the WiFi and Spotify credentials on a microSD card. Create a file called `spotify_diy_config.yaml` in the root of the card (FAT32 is recommended) and populate it with your details:
+
+```yaml
+wifiSsid: "YourWifiName"
+wifiPassword: "YourWifiPassword"
+clientId: "yourSpotifyClientId"
+clientSecret: "yourSpotifyClientSecret"
+refreshToken: "optionalRefreshToken"
+```
+
+Insert the card before powering the device. On boot it will attempt to read this file and connect using the supplied WiFi credentials, then use the Spotify details. If the file is missing or the WiFi connection fails, the captive portal is launched as before. Saving credentials through the portal will also mirror the updated YAML back to the SD card when it is available. Existing `spotify_diy_config.json` files are still read and will be converted to YAML automatically on first boot.
+
 ### Step 4 - Authenticating the device with your Spotify account
 
 The final step is to connect this device to your Spotify account. When the Wifi is configured correctly, it will enter "Refresh Token Mode".

--- a/SpotifyDiyThing/SpotifyDiyThing.ino
+++ b/SpotifyDiyThing/SpotifyDiyThing.ino
@@ -41,6 +41,8 @@ bool writeContextToNfc = true;
 // ----------------------------
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
+#include <SPI.h>
+#include <SD.h>
 
 #include <FS.h>
 #include "SPIFFS.h"
@@ -67,9 +69,19 @@ bool writeContextToNfc = true;
 // header is included as part of the SpotifyArduino libary
 #include <SpotifyArduinoCert.h>
 
-#include <ArduinoJson.h>
-
 WiFiClientSecure client;
+
+bool g_sdCardAvailable = false;
+
+#if defined(ARDUINO_ARCH_ESP32)
+#define SD_CARD_CS_PIN 5
+#define SD_CARD_SCK_PIN 18
+#define SD_CARD_MISO_PIN 19
+#define SD_CARD_MOSI_PIN 23
+SPIClass sdSpi(VSPI);
+#endif
+
+const unsigned long WIFI_CONNECT_TIMEOUT_MS = 20000;
 
 //------- Replace the following! ------
 
@@ -119,6 +131,42 @@ void drawWifiManagerMessage(WiFiManager *myWiFiManager)
   spotifyDisplay->drawWifiManagerMessage(myWiFiManager);
 }
 
+bool connectToConfiguredWifi(const char *ssid, const char *password)
+{
+  if (ssid == nullptr || ssid[0] == '\0')
+  {
+    return false;
+  }
+
+  Serial.print("Attempting to connect to WiFi network ");
+  Serial.println(ssid);
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid, password);
+  WiFi.setAutoReconnect(true);
+
+  unsigned long startAttemptTime = millis();
+
+  while (WiFi.status() != WL_CONNECTED && millis() - startAttemptTime < WIFI_CONNECT_TIMEOUT_MS)
+  {
+    delay(500);
+    Serial.print(".");
+  }
+
+  Serial.println();
+
+  if (WiFi.status() == WL_CONNECTED)
+  {
+    Serial.println("Connected to WiFi using stored credentials.");
+    return true;
+  }
+
+  Serial.println("Failed to connect using stored WiFi credentials.");
+  WiFi.disconnect(true);
+  delay(100);
+  return false;
+}
+
 void setup()
 {
   Serial.begin(115200);
@@ -159,18 +207,116 @@ void setup()
   }
   Serial.println("\r\nInitialisation done.");
 
+#if defined(ARDUINO_ARCH_ESP32)
+  sdSpi.begin(SD_CARD_SCK_PIN, SD_CARD_MISO_PIN, SD_CARD_MOSI_PIN, SD_CARD_CS_PIN);
+  if (SD.begin(SD_CARD_CS_PIN, sdSpi))
+  {
+    g_sdCardAvailable = true;
+    Serial.println("SD card initialisation done.");
+  }
+  else
+  {
+    Serial.println("SD card initialisation failed or not present.");
+  }
+#else
+  if (SD.begin())
+  {
+    g_sdCardAvailable = true;
+    Serial.println("SD card initialisation done.");
+  }
+  else
+  {
+    Serial.println("SD card initialisation failed or not present.");
+  }
+#endif
+
   refreshToken[0] = '\0';
-  if (!fetchConfigFile(refreshToken, clientId, clientSecret))
+  clientId[0] = '\0';
+  clientSecret[0] = '\0';
+  wifiSsid[0] = '\0';
+  wifiPassword[0] = '\0';
+
+  bool configLoaded = false;
+  if (g_sdCardAvailable)
+  {
+    bool sdConfigWasJson = false;
+    configLoaded = fetchConfigFromFs(SD, SPOTIFY_CONFIG_FILE, "SD",
+                                     refreshToken, sizeof(refreshToken),
+                                     clientId, sizeof(clientId),
+                                     clientSecret, sizeof(clientSecret),
+                                     wifiSsid, sizeof(wifiSsid),
+                                     wifiPassword, sizeof(wifiPassword),
+                                     &sdConfigWasJson);
+    if (configLoaded && sdConfigWasJson)
+    {
+      Serial.println(F("SD config was JSON formatted; rewriting as YAML."));
+      saveConfigFile(refreshToken, clientId, clientSecret, wifiSsid, wifiPassword);
+    }
+
+    if (!configLoaded)
+    {
+      sdConfigWasJson = false;
+      bool legacyJsonLoaded = fetchConfigFromFs(SD, LEGACY_SPOTIFY_CONFIG_JSON, "SD",
+                                               refreshToken, sizeof(refreshToken),
+                                               clientId, sizeof(clientId),
+                                               clientSecret, sizeof(clientSecret),
+                                               wifiSsid, sizeof(wifiSsid),
+                                               wifiPassword, sizeof(wifiPassword),
+                                               &sdConfigWasJson);
+      if (legacyJsonLoaded)
+      {
+        Serial.println(F("Migrating SD config from JSON to YAML."));
+        saveConfigFile(refreshToken, clientId, clientSecret, wifiSsid, wifiPassword);
+        configLoaded = true;
+      }
+    }
+  }
+
+  if (!configLoaded)
+  {
+    configLoaded = fetchConfigFile(refreshToken, sizeof(refreshToken),
+                                   clientId, sizeof(clientId),
+                                   clientSecret, sizeof(clientSecret),
+                                   wifiSsid, sizeof(wifiSsid),
+                                   wifiPassword, sizeof(wifiPassword));
+  }
+
+  if (!configLoaded)
   {
     // Failed to fetch config file, need to launch Wifi Manager
     forceConfig = true;
   }
 
-  setupWiFiManager(forceConfig, refreshToken, &saveConfigFile, &drawWifiManagerMessage);
+  bool connectedFromConfig = false;
+  if (!forceConfig)
+  {
+    connectedFromConfig = connectToConfiguredWifi(wifiSsid, wifiPassword);
+    if (!connectedFromConfig)
+    {
+      Serial.println("Falling back to WiFi manager for configuration.");
+      forceConfig = true;
+    }
+  }
+
+  if (forceConfig || WiFi.status() != WL_CONNECTED)
+  {
+    setupWiFiManager(forceConfig, refreshToken, &saveConfigFile, &drawWifiManagerMessage);
+  }
+  else
+  {
+    Serial.println(F("WiFi connected using stored credentials, skipping WiFi manager."));
+  }
 
   // If we are here we should be connected to the Wifi
-  Serial.print("IP address: ");
-  Serial.println(WiFi.localIP());
+  if (WiFi.status() == WL_CONNECTED)
+  {
+    Serial.print("IP address: ");
+    Serial.println(WiFi.localIP());
+  }
+  else
+  {
+    Serial.println("WiFi connection not established.");
+  }
 
   spotifySetup(spotifyDisplay, clientId, clientSecret);
 
@@ -198,7 +344,7 @@ void setup()
     {
       Serial.print("Refresh Token: ");
       Serial.println(refreshToken);
-      saveConfigFile(refreshToken, clientId, clientSecret);
+      saveConfigFile(refreshToken, clientId, clientSecret, wifiSsid, wifiPassword);
     }
   }
 

--- a/SpotifyDiyThing/WifiManagerHandler.h
+++ b/SpotifyDiyThing/WifiManagerHandler.h
@@ -6,14 +6,23 @@
 // RTC Memory Address for the DoubleResetDetector to use
 #define DRD_ADDRESS 0
 
+#include <cstring>
+
 #define WM_CLIENT_ID_LABEL "clientID"
 #define WM_CLIENT_SECRET_LABEL "clientSecret"
 #define WM_REFRESH_TOKEN_LABEL "refreshToken"
 
-DoubleResetDetector* drd;
+#define CLIENT_ID_MAX_LEN 50
+#define CLIENT_SECRET_MAX_LEN 50
+#define WIFI_SSID_MAX_LEN 32
+#define WIFI_PASSWORD_MAX_LEN 63
 
-char clientId[50];
-char clientSecret[50];
+DoubleResetDetector *drd;
+
+char clientId[CLIENT_ID_MAX_LEN];
+char clientSecret[CLIENT_SECRET_MAX_LEN];
+char wifiSsid[WIFI_SSID_MAX_LEN + 1];
+char wifiPassword[WIFI_PASSWORD_MAX_LEN + 1];
 
 //flag for saving data
 bool shouldSaveConfig = false;
@@ -24,12 +33,12 @@ void saveConfigCallback () {
   shouldSaveConfig = true;
 }
 
-void setupWiFiManager(bool forceConfig, char *refreshToken, void (*saveConfig)(char *, char *, char *), void (*configModeCallback)(WiFiManager *myWiFiManager)){
+void setupWiFiManager(bool forceConfig, char *refreshToken, void (*saveConfig)(char *, char *, char *, char *, char *), void (*configModeCallback)(WiFiManager *myWiFiManager)){
   WiFiManager wm;
   //set config save notify callback
   wm.setSaveConfigCallback(saveConfigCallback);
   //set callback that gets called when connecting to previous WiFi fails, and enters Access Point mode
-  wm.setAPCallback(configModeCallback);  
+  wm.setAPCallback(configModeCallback);
 
   WiFiManagerParameter clientIdParam(WM_CLIENT_ID_LABEL, "Client ID", clientId, 40);
   WiFiManagerParameter clientSecretParam(WM_CLIENT_SECRET_LABEL, "Client Secret", clientSecret, 40);
@@ -59,18 +68,43 @@ void setupWiFiManager(bool forceConfig, char *refreshToken, void (*saveConfig)(c
     }
   }
 
+  if (WiFi.status() == WL_CONNECTED)
+  {
+    String connectedSsid = WiFi.SSID();
+    strncpy(wifiSsid, connectedSsid.c_str(), WIFI_SSID_MAX_LEN);
+    wifiSsid[WIFI_SSID_MAX_LEN] = '\0';
+
+    String connectedPassword = WiFi.psk();
+    strncpy(wifiPassword, connectedPassword.c_str(), WIFI_PASSWORD_MAX_LEN);
+    wifiPassword[WIFI_PASSWORD_MAX_LEN] = '\0';
+  }
+
   //save the custom parameters to FS
   if (shouldSaveConfig)
   {
 
     strncpy(clientId, clientIdParam.getValue(), 40);
+    clientId[40 - 1] = '\0';
     strncpy(clientSecret, clientSecretParam.getValue(), 40);
+    clientSecret[40 - 1] = '\0';
     strncpy(refreshToken, clientRefreshToken.getValue(), 399);
+    refreshToken[399] = '\0';
 
-    saveConfig(refreshToken, clientId, clientSecret);
+    if (WiFi.status() == WL_CONNECTED)
+    {
+      String connectedSsid = WiFi.SSID();
+      strncpy(wifiSsid, connectedSsid.c_str(), WIFI_SSID_MAX_LEN);
+      wifiSsid[WIFI_SSID_MAX_LEN] = '\0';
+
+      String connectedPassword = WiFi.psk();
+      strncpy(wifiPassword, connectedPassword.c_str(), WIFI_PASSWORD_MAX_LEN);
+      wifiPassword[WIFI_PASSWORD_MAX_LEN] = '\0';
+    }
+
+    saveConfig(refreshToken, clientId, clientSecret, wifiSsid, wifiPassword);
     drd->stop();
     ESP.restart();
     delay(5000);
   }
-  
+
 }

--- a/SpotifyDiyThing/configFile.h
+++ b/SpotifyDiyThing/configFile.h
@@ -1,65 +1,579 @@
-#define SPOTIFY_CONFIG_JSON "/spotify_diy_config.json"
+#pragma once
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+#include <FS.h>
+#include <SPIFFS.h>
+#include <SD.h>
+
+#include <cstring>
+
+#define SPOTIFY_CONFIG_FILE "/spotify_diy_config.yaml"
+#define LEGACY_SPOTIFY_CONFIG_JSON "/spotify_diy_config.json"
 
 #define REFRESH_TOKEN_LABEL "refreshToken"
 #define CLIENT_ID_LABEL "clientId"
 #define CLIENT_SECRET_LABEL "clientSecret"
+#define WIFI_SSID_LABEL "wifiSsid"
+#define WIFI_PASSWORD_LABEL "wifiPassword"
 
-bool fetchConfigFile(char *refreshToken, char *clientId, char *clientSecret) {
-  if (SPIFFS.exists(SPOTIFY_CONFIG_JSON)) {
-    //file exists, reading and loading
-    Serial.println("reading config file");
-    File configFile = SPIFFS.open(SPOTIFY_CONFIG_JSON, "r");
-    if (configFile) {
-      Serial.println("opened config file");
-      StaticJsonDocument<512> json;
-      DeserializationError error = deserializeJson(json, configFile);
-      serializeJsonPretty(json, Serial);
-      if (!error) {
-        Serial.println("\nparsed json");
+extern bool g_sdCardAvailable;
 
-        if (json.containsKey(REFRESH_TOKEN_LABEL)) {
-          strcpy(refreshToken, json[REFRESH_TOKEN_LABEL]);
-        }
+inline void safeStringCopy(char *destination, size_t destinationLength, const char *source)
+{
+  if (destination == nullptr || destinationLength == 0)
+  {
+    return;
+  }
 
-        if (json.containsKey(CLIENT_ID_LABEL) && json.containsKey(CLIENT_SECRET_LABEL)) {
-          strcpy(clientId, json[CLIENT_ID_LABEL]);
-          strcpy(clientSecret, json[CLIENT_SECRET_LABEL]);
-        } else {
-          Serial.println("Config missing client ID or Secret");
-          return false;
-        }
+  if (source == nullptr)
+  {
+    destination[0] = '\0';
+    return;
+  }
 
-        return true;
+  strncpy(destination, source, destinationLength - 1);
+  destination[destinationLength - 1] = '\0';
+}
 
-      } else {
-        Serial.println("failed to load json config");
-        return false;
+inline String decodeDoubleQuotedValue(const String &value)
+{
+  String inner = value.substring(1, value.length() - 1);
+  String result;
+  result.reserve(inner.length());
+
+  for (size_t i = 0; i < inner.length(); ++i)
+  {
+    char c = inner.charAt(i);
+    if (c == '\\' && i + 1 < inner.length())
+    {
+      char next = inner.charAt(i + 1);
+      switch (next)
+      {
+      case 'n':
+        result += '\n';
+        break;
+      case 'r':
+        result += '\r';
+        break;
+      case 't':
+        result += '\t';
+        break;
+      case '\\':
+        result += '\\';
+        break;
+      case '"':
+        result += '"';
+        break;
+      default:
+        result += next;
+        break;
       }
-    } else {
-      Serial.println("Failed to open config file");
-      return false;
+      ++i;
     }
-  } else {
-    Serial.println("Config file does not exist");
+    else
+    {
+      result += c;
+    }
+  }
+
+  return result;
+}
+
+inline String decodeSingleQuotedValue(const String &value)
+{
+  String inner = value.substring(1, value.length() - 1);
+  inner.replace("''", "'");
+  return inner;
+}
+
+inline String normalizeYamlValue(String value)
+{
+  value.trim();
+  if (value.length() == 0)
+  {
+    return "";
+  }
+
+  if (value.startsWith("\"") && value.endsWith("\"") && value.length() >= 2)
+  {
+    return decodeDoubleQuotedValue(value);
+  }
+
+  if (value.startsWith("'") && value.endsWith("'") && value.length() >= 2)
+  {
+    return decodeSingleQuotedValue(value);
+  }
+
+  int commentIndex = value.indexOf('#');
+  if (commentIndex >= 0)
+  {
+    String beforeComment = value.substring(0, commentIndex);
+    beforeComment.trim();
+    value = beforeComment;
+  }
+
+  value.trim();
+  return value;
+}
+
+inline bool parseYamlConfig(File &configFile, const char *fsLabel,
+                            char *refreshToken, size_t refreshTokenLen,
+                            char *clientId, size_t clientIdLen,
+                            char *clientSecret, size_t clientSecretLen,
+                            char *wifiSsid, size_t wifiSsidLen,
+                            char *wifiPassword, size_t wifiPasswordLen)
+{
+  bool clientIdValid = false;
+  bool clientSecretValid = false;
+  bool refreshTokenSeen = false;
+  bool wifiSsidSeen = false;
+  bool wifiPasswordSeen = false;
+
+  while (configFile.available())
+  {
+    String rawLine = configFile.readStringUntil('\n');
+    rawLine.trim();
+
+    if (rawLine.length() == 0)
+    {
+      continue;
+    }
+
+    if (rawLine.startsWith("\xEF\xBB\xBF"))
+    {
+      rawLine.remove(0, 3);
+      rawLine.trim();
+      if (rawLine.length() == 0)
+      {
+        continue;
+      }
+    }
+
+    if (rawLine.startsWith("#"))
+    {
+      continue;
+    }
+
+    int colonIndex = rawLine.indexOf(':');
+    if (colonIndex < 0)
+    {
+      continue;
+    }
+
+    String key = rawLine.substring(0, colonIndex);
+    key.trim();
+
+    if (key.length() == 0)
+    {
+      continue;
+    }
+
+    String value = rawLine.substring(colonIndex + 1);
+    value = normalizeYamlValue(value);
+
+    if (key.equals(REFRESH_TOKEN_LABEL))
+    {
+      if (refreshToken != nullptr && refreshTokenLen > 0)
+      {
+        safeStringCopy(refreshToken, refreshTokenLen, value.c_str());
+      }
+      refreshTokenSeen = true;
+    }
+    else if (key.equals(CLIENT_ID_LABEL))
+    {
+      if (clientId != nullptr && clientIdLen > 0)
+      {
+        safeStringCopy(clientId, clientIdLen, value.c_str());
+      }
+      clientIdValid = true;
+    }
+    else if (key.equals(CLIENT_SECRET_LABEL))
+    {
+      if (clientSecret != nullptr && clientSecretLen > 0)
+      {
+        safeStringCopy(clientSecret, clientSecretLen, value.c_str());
+      }
+      clientSecretValid = true;
+    }
+    else if (key.equals(WIFI_SSID_LABEL))
+    {
+      if (wifiSsid != nullptr && wifiSsidLen > 0)
+      {
+        safeStringCopy(wifiSsid, wifiSsidLen, value.c_str());
+      }
+      wifiSsidSeen = true;
+    }
+    else if (key.equals(WIFI_PASSWORD_LABEL))
+    {
+      if (wifiPassword != nullptr && wifiPasswordLen > 0)
+      {
+        safeStringCopy(wifiPassword, wifiPasswordLen, value.c_str());
+      }
+      wifiPasswordSeen = true;
+    }
+  }
+
+  if (!refreshTokenSeen && refreshToken != nullptr && refreshTokenLen > 0)
+  {
+    refreshToken[0] = '\0';
+  }
+
+  if (!wifiSsidSeen && wifiSsid != nullptr && wifiSsidLen > 0)
+  {
+    wifiSsid[0] = '\0';
+  }
+
+  if (!wifiPasswordSeen && wifiPassword != nullptr && wifiPasswordLen > 0)
+  {
+    wifiPassword[0] = '\0';
+  }
+
+  if (!clientIdValid || !clientSecretValid)
+  {
+    Serial.println("Config missing client ID or Secret");
     return false;
+  }
+
+  Serial.print("Parsed YAML config from ");
+  Serial.println(fsLabel);
+  return true;
+}
+
+inline bool parseJsonConfig(File &configFile, const char *fsLabel,
+                            char *refreshToken, size_t refreshTokenLen,
+                            char *clientId, size_t clientIdLen,
+                            char *clientSecret, size_t clientSecretLen,
+                            char *wifiSsid, size_t wifiSsidLen,
+                            char *wifiPassword, size_t wifiPasswordLen)
+{
+  StaticJsonDocument<512> json;
+  DeserializationError error = deserializeJson(json, configFile);
+
+  if (error)
+  {
+    Serial.print("Failed to load json config from ");
+    Serial.println(fsLabel);
+    Serial.println(error.c_str());
+    return false;
+  }
+
+  if (refreshToken != nullptr && refreshTokenLen > 0)
+  {
+    if (json.containsKey(REFRESH_TOKEN_LABEL))
+    {
+      safeStringCopy(refreshToken, refreshTokenLen, json[REFRESH_TOKEN_LABEL]);
+    }
+    else
+    {
+      refreshToken[0] = '\0';
+    }
+  }
+
+  if (json.containsKey(CLIENT_ID_LABEL) && json.containsKey(CLIENT_SECRET_LABEL))
+  {
+    safeStringCopy(clientId, clientIdLen, json[CLIENT_ID_LABEL]);
+    safeStringCopy(clientSecret, clientSecretLen, json[CLIENT_SECRET_LABEL]);
+  }
+  else
+  {
+    Serial.println("Config missing client ID or Secret");
+    return false;
+  }
+
+  if (wifiSsid != nullptr && wifiSsidLen > 0)
+  {
+    if (json.containsKey(WIFI_SSID_LABEL))
+    {
+      safeStringCopy(wifiSsid, wifiSsidLen, json[WIFI_SSID_LABEL]);
+    }
+    else
+    {
+      wifiSsid[0] = '\0';
+    }
+  }
+
+  if (wifiPassword != nullptr && wifiPasswordLen > 0)
+  {
+    if (json.containsKey(WIFI_PASSWORD_LABEL))
+    {
+      safeStringCopy(wifiPassword, wifiPasswordLen, json[WIFI_PASSWORD_LABEL]);
+    }
+    else
+    {
+      wifiPassword[0] = '\0';
+    }
+  }
+
+  Serial.print("Parsed JSON config from ");
+  Serial.println(fsLabel);
+  return true;
+}
+
+inline bool fetchConfigFromFs(fs::FS &fs, const char *path, const char *fsLabel,
+                              char *refreshToken, size_t refreshTokenLen,
+                              char *clientId, size_t clientIdLen,
+                              char *clientSecret, size_t clientSecretLen,
+                              char *wifiSsid, size_t wifiSsidLen,
+                              char *wifiPassword, size_t wifiPasswordLen,
+                              bool *configWasJson = nullptr)
+{
+  if (!fs.exists(path))
+  {
+    Serial.print(fsLabel);
+    Serial.print(" config file does not exist at ");
+    Serial.println(path);
+    return false;
+  }
+
+  Serial.print("Reading config file from ");
+  Serial.print(fsLabel);
+  Serial.print(": ");
+  Serial.println(path);
+
+  File formatProbe = fs.open(path, "r");
+  if (!formatProbe)
+  {
+    Serial.print("Failed to open config file from ");
+    Serial.println(fsLabel);
+    return false;
+  }
+
+  int firstChar = -1;
+  while (formatProbe.available())
+  {
+    int peeked = formatProbe.peek();
+    if (peeked < 0)
+    {
+      break;
+    }
+
+    char c = static_cast<char>(peeked);
+    if (c == '\r' || c == '\n' || c == ' ' || c == '\t')
+    {
+      formatProbe.read();
+      continue;
+    }
+
+    if (static_cast<unsigned char>(c) == 0xEF && formatProbe.available() >= 3)
+    {
+      char bom[3];
+      size_t readCount = formatProbe.readBytes(bom, sizeof(bom));
+      if (readCount == sizeof(bom) && static_cast<unsigned char>(bom[0]) == 0xEF && static_cast<unsigned char>(bom[1]) == 0xBB && static_cast<unsigned char>(bom[2]) == 0xBF)
+      {
+        continue;
+      }
+      else
+      {
+        firstChar = static_cast<unsigned char>(bom[0]);
+        break;
+      }
+    }
+
+    firstChar = static_cast<unsigned char>(formatProbe.read());
+    break;
+  }
+  formatProbe.close();
+
+  if (firstChar == -1)
+  {
+    Serial.print("Config file on ");
+    Serial.print(fsLabel);
+    Serial.println(" is empty.");
+    return false;
+  }
+
+  bool fileIsJson = (firstChar == '{' || firstChar == '[');
+  if (configWasJson != nullptr)
+  {
+    *configWasJson = fileIsJson;
+  }
+
+  File configFile = fs.open(path, "r");
+  if (!configFile)
+  {
+    Serial.print("Failed to open config file from ");
+    Serial.println(fsLabel);
+    return false;
+  }
+
+  bool parsed = false;
+  if (fileIsJson)
+  {
+    parsed = parseJsonConfig(configFile, fsLabel,
+                             refreshToken, refreshTokenLen,
+                             clientId, clientIdLen,
+                             clientSecret, clientSecretLen,
+                             wifiSsid, wifiSsidLen,
+                             wifiPassword, wifiPasswordLen);
+  }
+  else
+  {
+    parsed = parseYamlConfig(configFile, fsLabel,
+                             refreshToken, refreshTokenLen,
+                             clientId, clientIdLen,
+                             clientSecret, clientSecretLen,
+                             wifiSsid, wifiSsidLen,
+                             wifiPassword, wifiPasswordLen);
+  }
+
+  configFile.close();
+  return parsed;
+}
+
+inline void writeYamlEscapedString(File &configFile, const char *value)
+{
+  configFile.print('"');
+
+  if (value != nullptr)
+  {
+    while (*value != '\0')
+    {
+      char c = *value;
+      switch (c)
+      {
+      case '\\':
+        configFile.print("\\\\");
+        break;
+      case '"':
+        configFile.print("\\\"");
+        break;
+      case '\n':
+        configFile.print("\\n");
+        break;
+      case '\r':
+        configFile.print("\\r");
+        break;
+      case '\t':
+        configFile.print("\\t");
+        break;
+      default:
+        configFile.print(c);
+        break;
+      }
+      ++value;
+    }
+  }
+
+  configFile.print('"');
+}
+
+inline void writeYamlField(File &configFile, const char *key, const char *value)
+{
+  configFile.print(key);
+  configFile.print(": ");
+  writeYamlEscapedString(configFile, value != nullptr ? value : "");
+  configFile.print('\n');
+}
+
+inline bool saveConfigToFs(fs::FS &fs, const char *path, const char *fsLabel,
+                           const char *refreshToken, const char *clientId,
+                           const char *clientSecret, const char *wifiSsid,
+                           const char *wifiPassword)
+{
+  File configFile = fs.open(path, "w");
+  if (!configFile)
+  {
+    Serial.print("Failed to open config file for writing on ");
+    Serial.println(fsLabel);
+    return false;
+  }
+
+  configFile.println("# Spotify DIY Thing credentials");
+  writeYamlField(configFile, CLIENT_ID_LABEL, clientId);
+  writeYamlField(configFile, CLIENT_SECRET_LABEL, clientSecret);
+  writeYamlField(configFile, REFRESH_TOKEN_LABEL, refreshToken);
+  writeYamlField(configFile, WIFI_SSID_LABEL, wifiSsid);
+  writeYamlField(configFile, WIFI_PASSWORD_LABEL, wifiPassword);
+  configFile.flush();
+  configFile.close();
+
+  Serial.print("Saved config to ");
+  Serial.print(fsLabel);
+  Serial.print(" (");
+  Serial.print(path);
+  Serial.println(")");
+  return true;
+}
+
+inline void removeLegacyConfig(fs::FS &fs, const char *fsLabel)
+{
+  if (fs.exists(LEGACY_SPOTIFY_CONFIG_JSON))
+  {
+    if (fs.remove(LEGACY_SPOTIFY_CONFIG_JSON))
+    {
+      Serial.print("Removed legacy JSON config from ");
+      Serial.println(fsLabel);
+    }
+    else
+    {
+      Serial.print("Failed to remove legacy JSON config from ");
+      Serial.println(fsLabel);
+    }
   }
 }
 
-void saveConfigFile(char *refreshToken, char *clientId, char *clientSecret) {
-  Serial.println(F("Saving config"));
-  StaticJsonDocument<512> json;
-  json[REFRESH_TOKEN_LABEL] = refreshToken;
-  json[CLIENT_ID_LABEL] = clientId;
-  json[CLIENT_SECRET_LABEL] = clientSecret;
+inline void saveConfigFile(char *refreshToken, char *clientId, char *clientSecret, char *wifiSsid, char *wifiPassword)
+{
+  Serial.println(F("Saving configuration to YAML"));
 
-  File configFile = SPIFFS.open(SPOTIFY_CONFIG_JSON, "w");
-  if (!configFile) {
-    Serial.println("failed to open config file for writing");
+  bool spiffsSaved = saveConfigToFs(SPIFFS, SPOTIFY_CONFIG_FILE, "SPIFFS",
+                                    refreshToken, clientId, clientSecret,
+                                    wifiSsid, wifiPassword);
+  if (spiffsSaved)
+  {
+    removeLegacyConfig(SPIFFS, "SPIFFS");
   }
 
-  serializeJsonPretty(json, Serial);
-  if (serializeJson(json, configFile) == 0) {
-    Serial.println(F("Failed to write to file"));
+  if (g_sdCardAvailable)
+  {
+    bool sdSaved = saveConfigToFs(SD, SPOTIFY_CONFIG_FILE, "SD",
+                                  refreshToken, clientId, clientSecret,
+                                  wifiSsid, wifiPassword);
+    if (sdSaved)
+    {
+      removeLegacyConfig(SD, "SD");
+    }
   }
-  configFile.close();
+}
+
+inline bool fetchConfigFile(char *refreshToken, size_t refreshTokenLen,
+                            char *clientId, size_t clientIdLen,
+                            char *clientSecret, size_t clientSecretLen,
+                            char *wifiSsid, size_t wifiSsidLen,
+                            char *wifiPassword, size_t wifiPasswordLen)
+{
+  bool configWasJson = false;
+  bool configLoaded = fetchConfigFromFs(SPIFFS, SPOTIFY_CONFIG_FILE, "SPIFFS",
+                                        refreshToken, refreshTokenLen,
+                                        clientId, clientIdLen,
+                                        clientSecret, clientSecretLen,
+                                        wifiSsid, wifiSsidLen,
+                                        wifiPassword, wifiPasswordLen,
+                                        &configWasJson);
+  if (configLoaded && configWasJson)
+  {
+    Serial.println(F("SPIFFS config was JSON formatted; rewriting as YAML."));
+    saveConfigFile(refreshToken, clientId, clientSecret, wifiSsid, wifiPassword);
+  }
+
+  if (!configLoaded)
+  {
+    configWasJson = false;
+    bool loadedJson = fetchConfigFromFs(SPIFFS, LEGACY_SPOTIFY_CONFIG_JSON, "SPIFFS",
+                                        refreshToken, refreshTokenLen,
+                                        clientId, clientIdLen,
+                                        clientSecret, clientSecretLen,
+                                        wifiSsid, wifiSsidLen,
+                                        wifiPassword, wifiPasswordLen,
+                                        &configWasJson);
+    if (loadedJson)
+    {
+      Serial.println(F("Migrating SPIFFS config from JSON to YAML."));
+      saveConfigFile(refreshToken, clientId, clientSecret, wifiSsid, wifiPassword);
+      configLoaded = true;
+    }
+  }
+
+  return configLoaded;
 }


### PR DESCRIPTION
## Summary
- initialize the SD card on boot, load credentials from it when present, and try connecting to WiFi before starting the captive portal
- extend config file helpers to parse YAML (with JSON fallback), migrate legacy configs, and mirror saves to the SD card
- capture WiFi credentials from WiFiManager and document the optional microSD workflow in the README using YAML

## Testing
- `pio run` *(fails: HTTPClientError while downloading the ESP32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_68d4134b65148330b9f91f203ce4c0bd