### PR TITLE
Add play/pause control when tapping album art

### DIFF
--- a/SpotifyDiyThing/cheapYellowLCD.h
+++ b/SpotifyDiyThing/cheapYellowLCD.h
@@ -145,6 +145,19 @@ public:
       {
         spotify_display->nextTrack();
       }
+      else if (playPauseStatus)
+      {
+        if (isCurrentlyPlaying)
+        {
+          spotify_display->pause();
+          isCurrentlyPlaying = false;
+        }
+        else
+        {
+          spotify_display->play();
+          isCurrentlyPlaying = true;
+        }
+      }
       drawTouchButtons(false, false);
       requestDueTime = 0;                                               // Some button has been pressed and acted on, it surely impacts the status so force a refresh
       touchScreenCoolDownTime = millis() + touchScreenCoolDownInterval; // Cool the touch off

--- a/SpotifyDiyThing/spotifyLogic.h
+++ b/SpotifyDiyThing/spotifyLogic.h
@@ -3,6 +3,7 @@ SpotifyDisplay *sp_Display;
 SpotifyArduino spotify(client, NULL, NULL);
 
 bool albumArtChanged = false;
+bool isCurrentlyPlaying = false;
 
 long songStartMillis;
 long songDuration;
@@ -67,6 +68,7 @@ void spotifyRefreshToken(const char *refreshToken)
 
 void handleCurrentlyPlaying(CurrentlyPlaying currentlyPlaying)
 {
+  isCurrentlyPlaying = currentlyPlaying.isPlaying;
   if (currentlyPlaying.trackUri != NULL)
   {
     if (!isSameTrack(currentlyPlaying.trackUri))
@@ -94,6 +96,10 @@ void handleCurrentlyPlaying(CurrentlyPlaying currentlyPlaying)
       // Song doesn't seem to be playing, do not update the progress
       songStartMillis = 0;
     }
+  }
+  else
+  {
+    isCurrentlyPlaying = false;
   }
 }
 
@@ -147,6 +153,7 @@ void updateCurrentlyPlaying(boolean forceUpdate)
     else if (status == 204)
     {
       songStartMillis = 0;
+      isCurrentlyPlaying = false;
       Serial.println("Doesn't seem to be anything playing");
     }
     else

--- a/SpotifyDiyThing/touchScreen.h
+++ b/SpotifyDiyThing/touchScreen.h
@@ -13,6 +13,9 @@
 
 bool previousTrackStatus = false;
 bool nextTrackStatus = false;
+bool playPauseStatus = false;
+
+extern bool isCurrentlyPlaying;
 
 //SPIClass mySpi = SPIClass(HSPI);
 //
@@ -32,6 +35,7 @@ void touchSetup(SpotifyArduino *spotifyObj) {
 bool handleTouched() {
   previousTrackStatus = false;
   nextTrackStatus = false;
+  playPauseStatus = false;
   //if (ts.tirqTouched() && ts.touched()) {
   if (ts.touched()) {
     CYD28_TS_Point p = ts.getPointScaled();
@@ -50,6 +54,9 @@ bool handleTouched() {
     } else if (p.x > 200) {
       nextTrackStatus = true;
       //spotify_touch->nextTrack();
+      return true;
+    } else if (p.y < 160) {
+      playPauseStatus = true;
       return true;
     }
   }


### PR DESCRIPTION
## Summary
- track the player's play state from the currently playing response
- detect touches on the album art region and set a play/pause flag
- toggle Spotify playback when the album art is tapped

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d78f65732483308172db44f5d0e4c8